### PR TITLE
Fix crash when apps had a space in their name

### DIFF
--- a/Overkill/PreferencesWindow.swift
+++ b/Overkill/PreferencesWindow.swift
@@ -68,7 +68,7 @@ class PreferencesWindow: NSWindowController {
             
             if (result != nil) {
                 var fullPath = (result!.absoluteString) + "/Contents/Info.plist"
-                fullPath = fullPath.replacingOccurrences(of: "file://", with: "")
+                fullPath = fullPath.replacingOccurrences(of: "file://", with: "").removingPercentEncoding!
                 let content = NSDictionary(contentsOfFile: fullPath)
                 let bundleIdentifier = content?.value(forKey: "CFBundleIdentifier") as! String
                 if (bundleIdentifier == "com.krausefx.Overkill") {


### PR DESCRIPTION
Before, the `fullPath` would be like `/Applications/App%20Store.app/Contents/Info.plist` and would not be able to find a file with that name. Easily fixed by doing a `removePercentEncoding!`

fixes #11