### PR TITLE
brew cask install -> brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Just download Overkill from the [link](https://github.com/KrauseFx/overkill-for-
 Also, you can install using Homebrew:
 
 ```
-brew cask install overkill
+brew install overkill
 ```
 
 ## Credits


### PR DESCRIPTION
~ brew cask install overkill
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.